### PR TITLE
SLR-1100: adjusted template for using substitution in arguments on windows nodes.

### DIFF
--- a/templates/userdata_windows.tpl
+++ b/templates/userdata_windows.tpl
@@ -4,7 +4,7 @@ ${pre_userdata}
 [string]$EKSBinDir = "$env:ProgramFiles\Amazon\EKS"
 [string]$EKSBootstrapScriptName = 'Start-EKSBootstrap.ps1'
 [string]$EKSBootstrapScriptFile = "$EKSBinDir\$EKSBootstrapScriptName"
-& $EKSBootstrapScriptFile -EKSClusterName ${cluster_name} -KubeletExtraArgs '${kubelet_extra_args}' 3>&1 4>&1 5>&1 6>&1
+& $EKSBootstrapScriptFile -EKSClusterName ${cluster_name} -KubeletExtraArgs "${kubelet_extra_args}" 3>&1 4>&1 5>&1 6>&1
 $LastError = if ($?) { 0 } else { $Error[0].Exception.HResult }
 
 ${additional_userdata}


### PR DESCRIPTION
# PR o'clock

## Description

I modified the windows user_data template to utilize double quotes instead of single quotes so we can pass in arguments like: 

```bash
node.kubernetes.io/lifecycle=$(Invoke-WebRequest -Uri http://169.254.169.254/latest/meta-data/instance-life-cycle | Select-Object -ExpandProperty Content)
```

This has worked in testing and production usage, but I want to get new features related to node groups. Unfortunately windows is still not supported yet for node_groups so I need to retain this functionality, but would like to merge this to the public module so I can stop maintaining a forked repo.

### Checklist

- [x] README.md has been updated after any changes to variables and outputs. See https://github.com/terraform-aws-modules/terraform-aws-eks/#doc-generation
